### PR TITLE
Update what the final container actually has within it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # About
-Builds a version of nginx complete with the [ngx_http_substitutions](https://github.com/yaoweibin/ngx_http_substitutions_filter_module) module and the [ngx_headers_more](https://github.com/openresty/headers-more-nginx-module) module, alongside setting groups for HTTP purposes.
+Builds a statically linked version of nginx complete with the [ngx_http_substitutions](https://github.com/yaoweibin/ngx_http_substitutions_filter_module) module and the [ngx_headers_more](https://github.com/openresty/headers-more-nginx-module) module, alongside setting groups for HTTP purposes. This version of nginx will only run you 10-15mb in size and _only_ contains a compiled nginx.
 
 
 ## Warranty

--- a/etc/group
+++ b/etc/group
@@ -1,0 +1,1 @@
+www-data:x:1000:www-data

--- a/etc/passwd
+++ b/etc/passwd
@@ -1,0 +1,1 @@
+www-data:x:1000:1000:Linux User,,,:/home/www-data:/sbin/nologin


### PR DESCRIPTION
At the moment we currently ship an alpine container which contains a myriad of things we don't need including a load of leftover build residue that we poorly clean up. What this version does instead is build nginx with the modules, statically linked and only containing what it actually needs to get the job done.

This takes us from a ~227mb container down to around ~12mb. It does make it harder to debug if you're used to shelling into a container (although you can still log output) - but otherwise this functions exactly as a dynamically linked container.