### PR TITLE
Move away from defined user in GH:A & remove PAT

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -14,11 +14,11 @@ jobs:
 
     - name: Build container & Deploy
       run: |
-        repo=${{ github.repository }}
-        repo=${repo,,}
+        repo_owner=${{ github.repository }}
+        repo_owner=${repo_owner,,}
 
-        docker build . -t ghcr.io/teddio/static-nginx:master
-        echo ${{ secrets.PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-        docker push ghcr.io/teddio/static-nginx:master
+        docker build . -t ghcr.io/$repo_owner/static-nginx:master
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        docker push ghcr.io/$repo_owner/static-nginx:master
         
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -16,6 +16,6 @@ jobs:
         repo=${{ github.repository }}
         repo=${repo,,}
 
-        docker build . -t ghcr.io/teddio/static-nginx:${GITHUB_SHA::8}
+        docker build . -t ghcr.io/${{ github.repository_owner }}/static-nginx:${GITHUB_SHA::8}
 
         

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,9 +13,9 @@ jobs:
 
     - name: Build container
       run: |
-        repo=${{ github.repository }}
-        repo=${repo,,}
+        repo_owner=${{ github.repository }}
+        repo_owner=${repo_owner,,}
 
-        docker build . -t ghcr.io/${{ github.repository_owner }}/static-nginx:${GITHUB_SHA::8}
+        docker build . -t ghcr.io/$repo_owner/static-nginx:${GITHUB_SHA::8}
 
         


### PR DESCRIPTION
GitHub finally came out with support for `GITHUB_TOKEN` usage instead of the PAT for the ghcr. Lets swap it over!