### PR TITLE
Bump 1.1.1k to 1.1.1l

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -2,8 +2,6 @@ name: Build Tests
 
 on:
   pull_request:
-    branches-ignore: 
-      - master
 
 jobs:
   test_build_job:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine as build
 
 ARG version=1.16.1
-ARG opensslversion=1.1.1k
+ARG opensslversion=1.1.1l
 ARG zlibversion=1.2.11
 
 RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers


### PR DESCRIPTION
Release which bumps to the new OpenSSL version published to resolve `CVE-2021-3711`.