### PR TITLE
OpenSSL 3.2.x support & bump nginx versions

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -8,7 +8,6 @@ on:
 concurrency:
   group: main
   cancel-in-progress: true
-
   
 jobs:
   build:
@@ -17,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.20.2, 1.22.1, 1.24.0, 1.25.1]
+        version: [1.22.1, 1.24.0, 1.25.5, 1.26.0]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.20.2, 1.22.1, 1.24.0, 1.25.1]      
+        version: [1.22.1, 1.24.0, 1.25.5, 1.26.0]
     steps:
     - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine as build
 
 ARG version=1.16.1
 ARG opensslversion=3.2.1
-ARG zlibversion=1.3
+ARG zlibversion=1.3.1
 
 RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine as build
 
 ARG version=1.16.1
-ARG opensslversion=1.1.1w
+ARG opensslversion=3.2.1
 ARG zlibversion=1.3
 
 RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers


### PR DESCRIPTION
- Upgrade from OpenSSL 1.1.1x line to OpenSSL 3.2.x
- Bump Zlib versions
- Build against latest Nginx versions