### PR TITLE
Include nginx mainline, drop non-lts + bump 1.26

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.25.5, 1.26.0]
+        version: [1.22.1, 1.24.0, 1.26.2, 1.27.3]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.25.5, 1.26.0]
+        version: [1.22.1, 1.24.0, 1.26.2, 1.27.3]
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
- Drop support for 1.25.x
- Bump 1.26 -> 1.26.2
- Add support for mainline 1.27.x