### PR TITLE
Bump nginx versions (1.26.x & 1.27.x)

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.2, 1.27.3]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.27.4]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.2, 1.27.3]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.27.4]
     steps:
     - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine as build
 
 ARG version=1.16.1
-ARG opensslversion=3.2.3
+ARG opensslversion=3.2.4
 ARG zlibversion=1.3.1
 
 RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers


### PR DESCRIPTION
Bump OpenSSL to `3.2.4`
Bump respective NGINX versions to minor patch versions. 