### PR TITLE
Update some nginx versions, swap to pcre2

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.3, 1.28.1, 1.30.1, 1.31.0]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
+        version: [1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        version: [1.26.3, 1.28.3, 1.30.2, 1.31.1]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
+        version: [1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.22.1, 1.24.0, 1.26.3, 1.28.1, 1.30.1, 1.31.0]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.26.3, 1.28.3, 1.30.2, 1.31.1]
+        version: [1.22.1, 1.24.0, 1.26.3, 1.28.3, 1.30.2, 1.31.1]
     steps:
     - uses: actions/checkout@v6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG version=1.30.2
 ARG opensslversion=3.5.6
 ARG zlibversion=1.3.2
 
-RUN apk add --no-cache unzip bash gcc make pcre2 build-base pcre2-dev perl-dev linux-headers curl
+RUN apk add --no-cache unzip bash gcc make pcre2 build-base pcre2-dev  pcre2-static perl-dev linux-headers curl
 
 RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     tar -xf nginx-${version}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,16 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     wget https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz && \
     tar -xf openssl-${opensslversion}.tar.gz
 
-RUN curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 \
-    -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36" \
+RUN case $((RANDOM % 5)) in \
+    0) UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/137.0.0.0 Safari/537.36' ;; \
+    1) UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 15_5) AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15' ;; \
+    2) UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/137.0.0.0 Safari/537.36' ;; \
+    3) UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0' ;; \
+    *) UA='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0' ;; \
+    esac && \
+    echo "Using User-Agent: $UA" && \
+    curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 \
+    -A "$UA" \
     -o zlib-${zlibversion}.tar.gz \
     https://www.zlib.net/zlib-${zlibversion}.tar.gz && \
     tar -xf zlib-${zlibversion}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.21 as build
+FROM alpine:3.23 AS build
 
 ARG version=1.30.2
 ARG opensslversion=3.5.6
 ARG zlibversion=1.3.2
 
-RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers
+RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers curl
 
 RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     tar -xf nginx-${version}.tar.gz && \
@@ -15,9 +15,9 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     wget https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz && \
     tar -xf openssl-${opensslversion}.tar.gz
 
-RUN wget --tries=5 --retry-connrefused --waitretry=5 --timeout=30 \
-    --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36" \
-    -O zlib-${zlibversion}.tar.gz \
+RUN curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 \
+    -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36" \
+    -o zlib-${zlibversion}.tar.gz \
     https://www.zlib.net/zlib-${zlibversion}.tar.gz && \
     tar -xf zlib-${zlibversion}.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     wget https://github.com/openresty/headers-more-nginx-module/archive/master.zip && \
     unzip master.zip && \
     wget https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz && \
-    tar -xf openssl-${opensslversion}.tar.gz && \
-    wget https://www.zlib.net/zlib-${zlibversion}.tar.gz && \
-    tar -xf zlib-${zlibversion}.tar.gz 
+    tar -xf openssl-${opensslversion}.tar.gz
+
+RUN wget --tries=5 --retry-connrefused --waitretry=5 --timeout=30 \
+    --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36" \
+    -O zlib-${zlibversion}.tar.gz \
+    https://www.zlib.net/zlib-${zlibversion}.tar.gz && \
+    tar -xf zlib-${zlibversion}.tar.gz
 
 WORKDIR /nginx-${version}
 RUN ./configure --with-cc-opt="-static -static-libgcc" \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG version=1.30.2
 ARG opensslversion=3.5.6
 ARG zlibversion=1.3.2
 
-RUN apk add --no-cache unzip bash gcc make pcre2 build-base pcre2-dev  pcre2-static perl-dev linux-headers curl
+RUN apk add --no-cache unzip bash gcc make pcre2 build-base pcre2-dev pcre2-static perl-dev linux-headers curl
 
 RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     tar -xf nginx-${version}.tar.gz && \
@@ -15,6 +15,7 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     wget https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz && \
     tar -xf openssl-${opensslversion}.tar.gz
 
+# Do this to deal with ZLib randomly giving us a 415 response, which seems to be some sort of jank rate limiting on their end.
 RUN case $((RANDOM % 5)) in \
     0) UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/137.0.0.0 Safari/537.36' ;; \
     1) UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 15_5) AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15' ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21 as build
 
-ARG version=1.30.1
+ARG version=1.30.2
 ARG opensslversion=3.5.6
 ARG zlibversion=1.3.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,12 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     tar -xf zlib-${zlibversion}.tar.gz
 
 WORKDIR /nginx-${version}
-RUN ./configure --with-cc-opt="-static -static-libgcc" \ 
+
+RUN extra_cc_opt=""; \
+    if [ "$(printf '%s\n' "$version" "1.28.3" | sort -V | head -n1)" = "$version" ] && [ "$version" != "1.28.3" ]; then \
+        extra_cc_opt="-Wno-error=unterminated-string-initialization"; \
+    fi; \
+    ./configure --with-cc-opt="-static -static-libgcc ${extra_cc_opt}" \
     --with-ld-opt="-static" \
     --with-zlib=../zlib-${zlibversion} \
     --add-module=/ngx_http_substitutions_filter_module-master \
@@ -46,7 +51,7 @@ RUN ./configure --with-cc-opt="-static -static-libgcc" \
     --with-http_auth_request_module \
     --with-http_addition_module \
     --with-http_sub_module \
-    --with-openssl=../openssl-${opensslversion} 
+    --with-openssl=../openssl-${opensslversion}
 
 RUN make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,8 @@ RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     wget https://github.com/openresty/headers-more-nginx-module/archive/master.zip && \
     unzip master.zip && \
     wget https://github.com/openssl/openssl/releases/download/openssl-${opensslversion}/openssl-${opensslversion}.tar.gz && \
-    tar -xf openssl-${opensslversion}.tar.gz
-
-# Do this to deal with ZLib randomly giving us a 415 response, which seems to be some sort of jank rate limiting on their end.
-RUN case $((RANDOM % 5)) in \
-    0) UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/137.0.0.0 Safari/537.36' ;; \
-    1) UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 15_5) AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15' ;; \
-    2) UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/137.0.0.0 Safari/537.36' ;; \
-    3) UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0' ;; \
-    *) UA='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0' ;; \
-    esac && \
-    echo "Using User-Agent: $UA" && \
-    curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 \
-    -A "$UA" \
-    -o zlib-${zlibversion}.tar.gz \
-    https://www.zlib.net/zlib-${zlibversion}.tar.gz && \
+    tar -xf openssl-${opensslversion}.tar.gz && \
+    wget https://github.com/madler/zlib/releases/download/v${zlibversion}/zlib-${zlibversion}.tar.gz && \
     tar -xf zlib-${zlibversion}.tar.gz
 
 WORKDIR /nginx-${version}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG version=1.30.2
 ARG opensslversion=3.5.6
 ARG zlibversion=1.3.2
 
-RUN apk add --no-cache unzip bash gcc make pcre build-base pcre-dev perl-dev linux-headers curl
+RUN apk add --no-cache unzip bash gcc make pcre2 build-base pcre2-dev perl-dev linux-headers curl
 
 RUN wget https://nginx.org/download/nginx-${version}.tar.gz && \
     tar -xf nginx-${version}.tar.gz && \


### PR DESCRIPTION
This pull request updates the version matrix and Docker build to use the latest patch releases for improved stability and security.

Also updates to pcre2. 